### PR TITLE
Remove top-level dependency on jq

### DIFF
--- a/install_cf.sh
+++ b/install_cf.sh
@@ -13,8 +13,8 @@ echo "================================================"
 pushd certs
 terraform init
 terraform apply -var "domain=${DOMAIN}" -auto-approve > /dev/null
-terraform output -json | jq -r '.bbl_cert.value' > bbl_cert.pem
-terraform output -json | jq -r '.bbl_private_key.value' > bbl_key
+terraform output bbl_cert >bbl_cert.pem
+terraform output bbl_private_key >bbl_key
 popd
 
 echo "================================================"


### PR DESCRIPTION
Terraform natively gives you the value of a specific output - no need to `jq` it!